### PR TITLE
chore: remove npm audit from circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,6 @@ jobs:
       - run:
           name: upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
-      - run:
-          name: audit
-          command: |
-             sudo npm install -g npm
-             npm audit
       - save_cache:
           key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
           paths:


### PR DESCRIPTION
Moving to use GitHub Security and Dependabot for tracking and patching vulnerabilities