### PR TITLE
fix: provide empty object when data is null in request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 .idea
 .vscode
 .nyc_output
+.env

--- a/lib/oneflow.js
+++ b/lib/oneflow.js
@@ -21,7 +21,7 @@ function OneFlowClient(baseUrl, token, secret, options = {}) {
 		const headers = makeHeaders(url, method, options);
 		const axiosRetry = options['axios-retry'] || {};
 		return client
-			.request({ method, url, data: data || {}, headers, 'axios-retry': axiosRetry })
+			.request({ method, url, data: data === null ? {} : data, headers, 'axios-retry': axiosRetry })
 			.then(res => res.data);
 	}
 

--- a/lib/oneflow.js
+++ b/lib/oneflow.js
@@ -21,7 +21,7 @@ function OneFlowClient(baseUrl, token, secret, options = {}) {
 		const headers = makeHeaders(url, method, options);
 		const axiosRetry = options['axios-retry'] || {};
 		return client
-			.request({ method, url, data, headers, 'axios-retry': axiosRetry })
+			.request({ method, url, data: data || {}, headers, 'axios-retry': axiosRetry })
 			.then(res => res.data);
 	}
 

--- a/test/oneflow.test.js
+++ b/test/oneflow.test.js
@@ -131,7 +131,6 @@ describe('Oneflow', function () {
 		    const result = await sdk.request('get', '/order', undefined);
 
 		    result.method.should.be.equal('get');
-			console.log(result.data);
 		    (result.data === undefined).should.equal(true);
 		});
 		

--- a/test/oneflow.test.js
+++ b/test/oneflow.test.js
@@ -131,7 +131,8 @@ describe('Oneflow', function () {
 		    const result = await sdk.request('get', '/order', undefined);
 
 		    result.method.should.be.equal('get');
-		    result.data.should.be.eql({});
+			console.log(result.data);
+		    (result.data === undefined).should.equal(true);
 		});
 		
 		it('should perform an http request with data=""', async () => {
@@ -140,7 +141,7 @@ describe('Oneflow', function () {
 		    const result = await sdk.request('get', '/order', '');
 
 		    result.method.should.be.equal('get');
-		    result.data.should.be.eql({});
+		    result.data.should.be.equal('');
 		});
 
 		it('should support service user requests', async () => {

--- a/test/oneflow.test.js
+++ b/test/oneflow.test.js
@@ -115,6 +115,33 @@ describe('Oneflow', function () {
 			    'content-type',
 		    ]);
 		});
+		
+		it('should perform an http request with data=null', async () => {
+		    stubs.axiosRequest = sinon.stub(sdk.client, 'request').callsFake(a => Promise.resolve({ data: a }));
+
+		    const result = await sdk.request('get', '/order', null);
+
+		    result.method.should.be.equal('get');
+		    result.data.should.be.eql({});
+		});
+		
+		it('should perform an http request with data=undefined', async () => {
+		    stubs.axiosRequest = sinon.stub(sdk.client, 'request').callsFake(a => Promise.resolve({ data: a }));
+
+		    const result = await sdk.request('get', '/order', undefined);
+
+		    result.method.should.be.equal('get');
+		    result.data.should.be.eql({});
+		});
+		
+		it('should perform an http request with data=""', async () => {
+		    stubs.axiosRequest = sinon.stub(sdk.client, 'request').callsFake(a => Promise.resolve({ data: a }));
+
+		    const result = await sdk.request('get', '/order', '');
+
+		    result.method.should.be.equal('get');
+		    result.data.should.be.eql({});
+		});
 
 		it('should support service user requests', async () => {
 		    stubs.axiosRequest = sinon.stub(sdk.client, 'request').callsFake(a => Promise.resolve({ data: a }));


### PR DESCRIPTION
## Context
https://hpinc.kanbanize.com/ctrl_board/49/cards/15343/details/
slack discussion https://gsbsolutions.slack.com/archives/C7VCV8EJX/p1636038145060800

For some reason passing data=null causes 500 axios error. This is a workaround to prevent such behavior.