### PR TITLE
fix: isTooManyRequestsError in custom retry functionality

### DIFF
--- a/lib/customRetry.js
+++ b/lib/customRetry.js
@@ -1,14 +1,18 @@
 const axiosRetry = require('axios-retry');
 
 function isRetryableError(error) {
-    return axiosRetry.isNetworkOrIdempotentRequestError(error) || (error.response.status === 429);
+    return axiosRetry.isNetworkOrIdempotentRequestError(error) || isTooManyRequestsError(error);
 }
 
 function exponentialDelay(retryCount, error) {
-    const coefficient = (error.response.status === 429) ? (300 * 60) : 100; // assume 429 limit by minute
+    const coefficient = isTooManyRequestsError(error) ? (300 * 60) : 100; // assume 429 limit by minute
     const delay = Math.pow(2, retryCount) * coefficient;
     const randomSum = delay * 0.4 * Math.random(); // 0-40% of the delay
     return delay + randomSum;
 }
 
-module.exports = { isRetryableError, exponentialDelay }
+function isTooManyRequestsError(error) {
+	return !!(error && error.response && error.response.status === 429);
+}
+
+module.exports = { isRetryableError, exponentialDelay, isTooManyRequestsError };

--- a/test/customRetry.test.js
+++ b/test/customRetry.test.js
@@ -2,7 +2,7 @@ require('should');
 const _ = require('lodash');
 const sinon = require('sinon');
 const axiosRetry = require('axios-retry');
-const { isRetryableError, exponentialDelay } = require('../lib/customRetry');
+const { isRetryableError, exponentialDelay, isTooManyRequestsError } = require('../lib/customRetry');
 
 describe('CustomRetry', function () {
     let stubs = {};
@@ -61,6 +61,38 @@ describe('CustomRetry', function () {
             const firstDelay = exponentialDelay(1, error);
             const seconDelay = exponentialDelay(2, error);
             firstDelay.should.be.below(seconDelay);
+        });
+    });
+    
+    describe('isTooManyRequestsError', () => {
+        it('should return false if error is not defined', done => {
+            const result = isTooManyRequestsError();
+            result.should.equal(false);
+            done();
+        });
+        
+        it('should return false if response is not defined', done => {
+            const result = isTooManyRequestsError({});
+            result.should.equal(false);
+            done();
+        });
+        
+        it('should return false if status is not defined', done => {
+            const result = isTooManyRequestsError({ response: {} });
+            result.should.equal(false);
+            done();
+        });
+        
+        it('should return false if status is not equal 429', done => {
+            const result = isTooManyRequestsError({ response: { sattus: 400 } });
+            result.should.equal(false);
+            done();
+        });
+        
+        it('should return true if status is equal 429', done => {
+            const result = isTooManyRequestsError({ response: { sattus: 429 } });
+            result.should.equal(false);
+            done();
         });
     });
 });


### PR DESCRIPTION
## Context
https://hpinc.kanbanize.com/ctrl_board/49/cards/15343/details/

The goal of this PR is to fix error from unit tests https://app.circleci.com/pipelines/github/oneflow/shopify-piazza/440/workflows/6321e91f-02b1-4fec-9596-781095cbaa21/jobs/768